### PR TITLE
Add environment configuration

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8081

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://api.example.com

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # powerfitnessWeb
 backoffice admin de gym power fitness
+
+## Environment Configuration
+
+The application uses Vite environment files to configure the API base URL.
+
+Create `.env.local` for local development and `.env.production` for the
+production build. Each file should define `VITE_API_BASE_URL`:
+
+```
+VITE_API_BASE_URL=http://localhost:8081
+```
+
+Adjust the value in `.env.production` to match the production API endpoint.

--- a/src/pages/ConfiguracionAlumno/ConfiguracionAlumno.tsx
+++ b/src/pages/ConfiguracionAlumno/ConfiguracionAlumno.tsx
@@ -18,7 +18,7 @@ import {
   TableRow,
   CircularProgress,
 } from "@mui/material";
-import axios from "axios";
+import api from "../../services/api";
 
 interface AlumnoConfiguracion {
   idAlumno: number;
@@ -88,7 +88,7 @@ const ConfiguracionAlumno = () => {
       const resultados: AlumnoConfiguracion[] = [];
       for (let email of lista) {
         try {
-          const res = await axios.get(`http://localhost:8080/api/configuracionAlumno/${encodeURIComponent(email)}`);
+          const res = await api.get(`/api/configuracionAlumno/${encodeURIComponent(email)}`);
           resultados.push({ ...res.data, email, validado: false });
         } catch (err) {
           console.error(err);

--- a/src/pages/Platos/Platos.tsx
+++ b/src/pages/Platos/Platos.tsx
@@ -4,7 +4,7 @@ import {
   TextField, Typography, Paper, Table, TableBody, TableCell,
   TableContainer, TableHead, TableRow
 } from "@mui/material";
-import axios from "axios";
+import api from "../../services/api";
 
 interface Item {
   id: number;
@@ -30,7 +30,7 @@ const Platos = () => {
     const formData = new FormData();
     formData.append("archivo", file);
 
-    const response = await axios.post("http://localhost:8080/api/imagen-plato", formData, {
+    const response = await api.post("/api/imagen-plato", formData, {
       headers: { "Content-Type": "multipart/form-data" },
     });
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,10 @@
 import axios from 'axios';
 
-axios.interceptors.request.use(config => {
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || ''
+});
+
+api.interceptors.request.use(config => {
   const token = localStorage.getItem('token');
   if (token) {
     config.headers = config.headers ?? {};
@@ -9,4 +13,4 @@ axios.interceptors.request.use(config => {
   return config;
 });
 
-export default axios;
+export default api;


### PR DESCRIPTION
## Summary
- add Vite environment files for local and production
- configure axios base URL using environment variable
- use shared API instance in ConfiguracionAlumno and Platos pages
- document environment setup in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68740cbe74e08327a2dd27a679b83743