### PR TITLE
Update rutina form to send new JSON

### DIFF
--- a/src/services/EjerciciosService.ts
+++ b/src/services/EjerciciosService.ts
@@ -1,0 +1,11 @@
+import axios from "./api";
+
+const API_URL = "/api/ejercicios";
+
+class EjerciciosService {
+  getAll() {
+    return axios.get(API_URL);
+  }
+}
+
+export default new EjerciciosService();


### PR DESCRIPTION
## Summary
- add `EjerciciosService` to retrieve exercises
- simplify `Rutinas` page to build routine payload
- allow selecting alumno and ejercicio from backend lists

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68740f4f33408327a089b7b3a272d3ea