### PR TITLE
Add development proxy for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ VITE_API_BASE_URL=http://localhost:8081
 
 Ajusta el valor de `.env.production` para que apunte a la API real en producción.
 
+Durante el desarrollo, la configuración de Vite incluye un *proxy* que redirige
+las peticiones a rutas que empiecen por `/api` hacia la URL definida en
+`VITE_API_BASE_URL`. Esto evita los problemas de CORS mientras trabajas en
+local.
+
 ## Levantar el proyecto en local
 
 1. Instala las dependencias del proyecto:

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,7 +1,14 @@
 import axios from 'axios';
 
+// Cuando se ejecuta en modo desarrollo usamos "/api" para que Vite redireccione
+// las peticiones al backend definido en `VITE_API_BASE_URL` mediante su proxy.
+// En producción se utiliza directamente la URL proporcionada por la variable.
+const baseURL = import.meta.env.DEV
+  ? '/api'
+  : import.meta.env.VITE_API_BASE_URL || '';
+
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || ''
+  baseURL
 });
 
 api.interceptors.request.use(config => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,19 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  plugins: [react()]
+// Configuración de Vite. Durante el desarrollo se configura un proxy que
+// redirige las llamadas a "/api" al backend indicado en `VITE_API_BASE_URL`.
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  return {
+    plugins: [react()],
+    server: {
+      proxy: {
+        '/api': {
+          target: env.VITE_API_BASE_URL,
+          changeOrigin: true
+        }
+      }
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- configure Vite server proxy to redirect `/api` to the backend URL
- use `/api` base URL in development
- document the proxy usage in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876b5e65bb88327a96a3d47e72b04bb