### PR TITLE
Add custom alerts and prevent outside modal close

### DIFF
--- a/src/pages/Alumnos/Alumnos.tsx
+++ b/src/pages/Alumnos/Alumnos.tsx
@@ -6,6 +6,7 @@ import {
 } from "@mui/material";
 import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
 import AlumnosService from "../../services/AlumnosService";
+import { showError, showSuccess } from "../../utils/alerts";
 
 interface Item {
   id: number;
@@ -53,6 +54,9 @@ const Alumnos = () => {
         telefono: nuevo.telefono,
       });
       setItems([...items, { ...nuevo, id: items.length + 1 }]);
+      showSuccess('Alumno guardado correctamente');
+    } catch (error) {
+      showError('Error al guardar alumno');
     } finally {
       setOpenForm(false);
     }
@@ -101,7 +105,13 @@ const Alumnos = () => {
         </Table>
       </TableContainer>
 
-      <Dialog open={openForm} onClose={() => setOpenForm(false)}>
+      <Dialog
+        open={openForm}
+        onClose={(e, r) => {
+          if (r === 'backdropClick' || r === 'escapeKeyDown') return;
+          setOpenForm(false);
+        }}
+      >
         <DialogTitle>Nuevo Alumno</DialogTitle>
       <DialogContent>
         <TextField fullWidth margin="dense" label="Nombre" value={nuevo.nombre} onChange={(e) => setNuevo({ ...nuevo, nombre: e.target.value })} />
@@ -116,7 +126,15 @@ const Alumnos = () => {
         </DialogActions>
       </Dialog>
 
-      <Dialog open={openDetalle} onClose={() => setOpenDetalle(false)} fullWidth maxWidth="md">
+      <Dialog
+        open={openDetalle}
+        onClose={(e, r) => {
+          if (r === 'backdropClick' || r === 'escapeKeyDown') return;
+          setOpenDetalle(false);
+        }}
+        fullWidth
+        maxWidth="md"
+      >
         <DialogTitle>Detalle de {selectedAlumno?.nombre}</DialogTitle>
         <DialogContent dividers>
           <Tabs value={tabIndex} onChange={(_, v) => setTabIndex(v)}>

--- a/src/pages/Asistencias/Asistencias.tsx
+++ b/src/pages/Asistencias/Asistencias.tsx
@@ -20,6 +20,7 @@ import {
   Select,
   MenuItem,
 } from "@mui/material";
+import { showError, showSuccess } from "../../utils/alerts";
 
 interface Asistencia {
   id: number;
@@ -50,8 +51,13 @@ const Asistencias = () => {
   };
 
   const handleGuardar = () => {
-    setAsistencias([...asistencias, { ...nueva, id: asistencias.length + 1 }]);
-    setOpen(false);
+    try {
+      setAsistencias([...asistencias, { ...nueva, id: asistencias.length + 1 }]);
+      setOpen(false);
+      showSuccess('Asistencia guardada correctamente');
+    } catch (error) {
+      showError('Error al guardar asistencia');
+    }
   };
 
   const filtered = asistencias.filter(
@@ -153,7 +159,13 @@ const Asistencias = () => {
         </Table>
       </TableContainer>
 
-      <Dialog open={open} onClose={() => setOpen(false)}>
+      <Dialog
+        open={open}
+        onClose={(e, r) => {
+          if (r === 'backdropClick' || r === 'escapeKeyDown') return;
+          setOpen(false);
+        }}
+      >
         <DialogTitle>Nueva Asistencia</DialogTitle>
         <DialogContent>
           <TextField

--- a/src/pages/AvancesNutricionales/AvancesNutricionales.tsx
+++ b/src/pages/AvancesNutricionales/AvancesNutricionales.tsx
@@ -19,6 +19,7 @@ import {
   Card,
   CardContent
 } from "@mui/material";
+import { showError, showSuccess } from "../../utils/alerts";
 import {
   LineChart,
   Line,
@@ -74,8 +75,13 @@ const AvancesNutricionales = () => {
   };
 
   const handleGuardar = () => {
-    setItems([...items, { ...nuevo, id: items.length + 1 }]);
-    setOpen(false);
+    try {
+      setItems([...items, { ...nuevo, id: items.length + 1 }]);
+      setOpen(false);
+      showSuccess('Registro guardado correctamente');
+    } catch (error) {
+      showError('Error al guardar registro');
+    }
   };
 
   return (
@@ -194,7 +200,13 @@ const AvancesNutricionales = () => {
         </Grid>
       </Grid>
 
-      <Dialog open={open} onClose={() => setOpen(false)}>
+      <Dialog
+        open={open}
+        onClose={(e, r) => {
+          if (r === 'backdropClick' || r === 'escapeKeyDown') return;
+          setOpen(false);
+        }}
+      >
         <DialogTitle>Nuevo AvancesNutricionales</DialogTitle>
         <DialogContent>
           <TextField fullWidth margin="dense" label="Fecha" value={nuevo.fecha} onChange={(e) => setNuevo({ ...nuevo, fecha: e.target.value })} />

--- a/src/pages/ConfiguracionAlumno/ConfiguracionAlumno.tsx
+++ b/src/pages/ConfiguracionAlumno/ConfiguracionAlumno.tsx
@@ -201,7 +201,15 @@ const ConfiguracionAlumno = () => {
         </TableContainer>
       )}
 
-      <Dialog open={!!selectedAlumno} onClose={() => setSelectedAlumno(null)} fullWidth maxWidth="md">
+      <Dialog
+        open={!!selectedAlumno}
+        onClose={(e, r) => {
+          if (r === 'backdropClick' || r === 'escapeKeyDown') return;
+          setSelectedAlumno(null);
+        }}
+        fullWidth
+        maxWidth="md"
+      >
         <DialogTitle>Validar información de {selectedAlumno?.nombreCompleto}</DialogTitle>
         <DialogContent>
           <Typography variant="subtitle1">Edad: {selectedAlumno?.edad} años</Typography>
@@ -259,7 +267,13 @@ const ConfiguracionAlumno = () => {
       </DialogActions>
       </Dialog>
 
-      <Dialog open={!!progresoAlumno} onClose={() => setProgresoAlumno(null)}>
+      <Dialog
+        open={!!progresoAlumno}
+        onClose={(e, r) => {
+          if (r === 'backdropClick' || r === 'escapeKeyDown') return;
+          setProgresoAlumno(null);
+        }}
+      >
         <DialogTitle>Progreso de {progresoAlumno?.nombreCompleto}</DialogTitle>
         <DialogContent>
           <Typography>Progreso no disponible en esta demo.</Typography>

--- a/src/pages/CuentasCorrientes/CuentasCorrientes.tsx
+++ b/src/pages/CuentasCorrientes/CuentasCorrientes.tsx
@@ -134,7 +134,10 @@ const CuentasCorrientes = () => {
 
       <Dialog
         open={openDetalle}
-        onClose={() => setOpenDetalle(false)}
+        onClose={(e, r) => {
+          if (r === 'backdropClick' || r === 'escapeKeyDown') return;
+          setOpenDetalle(false);
+        }}
         fullWidth
         maxWidth="sm"
       >

--- a/src/pages/PlanesNutricionales/PlanesNutricionales.tsx
+++ b/src/pages/PlanesNutricionales/PlanesNutricionales.tsx
@@ -1,9 +1,22 @@
 import React, { useState } from "react";
 import {
-  Box, Button, Dialog, DialogActions, DialogContent, DialogTitle,
-  TextField, Typography, Paper, Table, TableBody, TableCell,
-  TableContainer, TableHead, TableRow
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
 } from "@mui/material";
+import { showError, showSuccess } from "../../utils/alerts";
 
 interface Item {
   id: number;
@@ -23,8 +36,13 @@ const PlanesNutricionales = () => {
   };
 
   const handleGuardar = () => {
-    setItems([...items, { ...nuevo, id: items.length + 1 }]);
-    setOpen(false);
+    try {
+      setItems([...items, { ...nuevo, id: items.length + 1 }]);
+      setOpen(false);
+      showSuccess('Plan guardado correctamente');
+    } catch (error) {
+      showError('Error al guardar plan');
+    }
   };
 
   return (
@@ -56,7 +74,13 @@ const PlanesNutricionales = () => {
         </Table>
       </TableContainer>
 
-      <Dialog open={open} onClose={() => setOpen(false)}>
+      <Dialog
+        open={open}
+        onClose={(e, r) => {
+          if (r === 'backdropClick' || r === 'escapeKeyDown') return;
+          setOpen(false);
+        }}
+      >
         <DialogTitle>Nuevo PlanesNutricionales</DialogTitle>
         <DialogContent>
           <TextField fullWidth margin="dense" label="Nombre" value={nuevo.nombre} onChange={(e) => setNuevo({ ...nuevo, nombre: e.target.value })} />

--- a/src/pages/PlanesYCuotasPendientes/PlanesYCuotasPendientes.tsx
+++ b/src/pages/PlanesYCuotasPendientes/PlanesYCuotasPendientes.tsx
@@ -1,9 +1,22 @@
 import React, { useState } from "react";
 import {
-  Box, Button, Dialog, DialogActions, DialogContent, DialogTitle,
-  TextField, Typography, Paper, Table, TableBody, TableCell,
-  TableContainer, TableHead, TableRow
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
 } from "@mui/material";
+import { showError, showSuccess } from "../../utils/alerts";
 
 interface Item {
   id: number;
@@ -23,8 +36,13 @@ const PlanesYCuotasPendientes = () => {
   };
 
   const handleGuardar = () => {
-    setItems([...items, { ...nuevo, id: items.length + 1 }]);
-    setOpen(false);
+    try {
+      setItems([...items, { ...nuevo, id: items.length + 1 }]);
+      setOpen(false);
+      showSuccess('Plan guardado correctamente');
+    } catch (error) {
+      showError('Error al guardar plan');
+    }
   };
 
   return (
@@ -56,7 +74,13 @@ const PlanesYCuotasPendientes = () => {
         </Table>
       </TableContainer>
 
-      <Dialog open={open} onClose={() => setOpen(false)}>
+      <Dialog
+        open={open}
+        onClose={(e, r) => {
+          if (r === 'backdropClick' || r === 'escapeKeyDown') return;
+          setOpen(false);
+        }}
+      >
         <DialogTitle>Nuevo PlanesYCuotasPendientes</DialogTitle>
         <DialogContent>
           <TextField fullWidth margin="dense" label="Plan" value={nuevo.plan} onChange={(e) => setNuevo({ ...nuevo, plan: e.target.value })} />

--- a/src/pages/Platos/Platos.tsx
+++ b/src/pages/Platos/Platos.tsx
@@ -1,10 +1,23 @@
 import React, { useState } from "react";
 import {
-  Box, Button, Dialog, DialogActions, DialogContent, DialogTitle,
-  TextField, Typography, Paper, Table, TableBody, TableCell,
-  TableContainer, TableHead, TableRow
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
 } from "@mui/material";
 import api from "../../services/api";
+import { showError, showSuccess } from "../../utils/alerts";
 
 interface Item {
   id: number;
@@ -54,8 +67,9 @@ const Platos = () => {
       const nuevoPlato = { ...nuevo, imagen: urlImagen, id: items.length + 1 };
       setItems([...items, nuevoPlato]);
       setOpen(false);
+      showSuccess("Plato guardado correctamente");
     } catch (error) {
-      alert("Error al subir imagen o guardar plato");
+      showError("Error al subir imagen o guardar plato");
       console.error(error);
     }
   };
@@ -96,7 +110,13 @@ const Platos = () => {
         </Table>
       </TableContainer>
 
-      <Dialog open={open} onClose={() => setOpen(false)}>
+      <Dialog
+        open={open}
+        onClose={(e, r) => {
+          if (r === "backdropClick" || r === "escapeKeyDown") return;
+          setOpen(false);
+        }}
+      >
         <DialogTitle>Nuevo Plato</DialogTitle>
         <DialogContent>
           <TextField fullWidth margin="dense" label="Nombre" value={nuevo.nombre} onChange={(e) => setNuevo({ ...nuevo, nombre: e.target.value })} />

--- a/src/pages/Rutinas/Rutinas.tsx
+++ b/src/pages/Rutinas/Rutinas.tsx
@@ -24,6 +24,7 @@ import AddIcon from '@mui/icons-material/Add';
 import RutinasService from "../../services/RutinasService";
 import AlumnosService from "../../services/AlumnosService";
 import EjerciciosService from "../../services/EjerciciosService";
+import { showError, showSuccess } from "../../utils/alerts";
 
 interface Alumno {
   id: number;
@@ -104,16 +105,22 @@ const Rutinas = () => {
   };
 
   const handleGuardar = async () => {
-    await RutinasService.create(rutina);
-    setItems([...items, rutina]);
-    setOpen(false);
-    setRutina({
-      idAlumno: 0,
-      nombre: '',
-      objetivo: '',
-      diasPorSemana: '1',
-      dias: [{ dia: 'Lunes', ejercicios: [] }],
-    });
+    try {
+      await RutinasService.create(rutina);
+      setItems([...items, rutina]);
+      showSuccess('Rutina guardada correctamente');
+    } catch (error) {
+      showError('Error al guardar rutina');
+    } finally {
+      setOpen(false);
+      setRutina({
+        idAlumno: 0,
+        nombre: '',
+        objetivo: '',
+        diasPorSemana: '1',
+        dias: [{ dia: 'Lunes', ejercicios: [] }],
+      });
+    }
   };
 
   return (
@@ -146,7 +153,15 @@ const Rutinas = () => {
         </Table>
       </TableContainer>
 
-      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="lg" fullWidth>
+      <Dialog
+        open={open}
+        onClose={(e, r) => {
+          if (r === 'backdropClick' || r === 'escapeKeyDown') return;
+          setOpen(false);
+        }}
+        maxWidth="lg"
+        fullWidth
+      >
         <DialogTitle>Nueva Rutina</DialogTitle>
         <DialogContent>
           <FormControl fullWidth margin="dense">

--- a/src/utils/alerts.ts
+++ b/src/utils/alerts.ts
@@ -1,0 +1,7 @@
+export const showSuccess = (message: string) => {
+  alert(message); // Reemplazar por SweetAlert en un entorno con dependencias
+};
+
+export const showError = (message: string) => {
+  alert(message); // Reemplazar por SweetAlert en un entorno con dependencias
+};


### PR DESCRIPTION
## Summary
- add simple alert helpers
- show success and error messages when saving data
- stop dialogs from closing on backdrop or escape

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876da5a76048327a247bff1c1bba812