### PR TITLE
Add summary of paid amount in account detail

### DIFF
--- a/src/pages/CuentasCorrientes/CuentasCorrientes.tsx
+++ b/src/pages/CuentasCorrientes/CuentasCorrientes.tsx
@@ -143,6 +143,16 @@ const CuentasCorrientes = () => {
       >
         <DialogTitle>Detalle de {selectedAlumno?.nombre}</DialogTitle>
         <DialogContent>
+          {selectedAlumno && (
+            <Box mb={2}>
+              <Typography variant="body1" color="textSecondary">
+                Deuda Mensual: ${selectedAlumno.deuda}
+              </Typography>
+              <Typography variant="body1" color="textSecondary">
+                Total Pagado: ${totalPagadoAlumno}
+              </Typography>
+            </Box>
+          )}
           <Table>
             <TableHead>
               <TableRow>
@@ -161,11 +171,6 @@ const CuentasCorrientes = () => {
               ))}
             </TableBody>
           </Table>
-          <Box mt={2}>
-            <Typography variant="subtitle1" color="orange">
-              Total Pagado: ${totalPagadoAlumno}
-            </Typography>
-          </Box>
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setOpenDetalle(false)} color="inherit">


### PR DESCRIPTION
## Summary
- show monthly debt and paid total when viewing student details

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68771c3e038883278221993a83936780