### PR TITLE
Replace weight graphs with strength progress

### DIFF
--- a/src/pages/Alumnos/Alumnos.tsx
+++ b/src/pages/Alumnos/Alumnos.tsx
@@ -67,11 +67,12 @@ const Alumnos = () => {
     setOpenDetalle(true);
   };
 
-  const pesoData = [
-    { mes: "Ene", peso: 75 },
-    { mes: "Feb", peso: 74 },
-    { mes: "Mar", peso: 72 },
-    { mes: "Abr", peso: 71 },
+  // Datos de ejemplo para mostrar la evolución de fuerza en press de banca
+  const fuerzaData = [
+    { mes: "Ene", pressBanca: 60 },
+    { mes: "Feb", pressBanca: 65 },
+    { mes: "Mar", pressBanca: 70 },
+    { mes: "Abr", pressBanca: 75 },
   ];
 
   return (
@@ -149,10 +150,10 @@ const Alumnos = () => {
                 <Avatar src="/img/progreso1.jpg" sx={{ width: 80, height: 80 }} />
                 <Avatar src="/img/progreso2.jpg" sx={{ width: 80, height: 80 }} />
               </Box>
-              <Typography color="orange" variant="subtitle1" sx={{ mt: 2 }}>Peso corporal</Typography>
+              <Typography color="orange" variant="subtitle1" sx={{ mt: 2 }}>Press de banca</Typography>
               <ResponsiveContainer width="100%" height={200}>
-                <LineChart data={pesoData}>
-                  <Line type="monotone" dataKey="peso" stroke="#FFA726" />
+                <LineChart data={fuerzaData}>
+                  <Line type="monotone" dataKey="pressBanca" stroke="#FFA726" />
                   <CartesianGrid stroke="#ccc" />
                   <XAxis dataKey="mes" />
                   <YAxis />

--- a/src/pages/AvancesNutricionales/AvancesNutricionales.tsx
+++ b/src/pages/AvancesNutricionales/AvancesNutricionales.tsx
@@ -45,11 +45,12 @@ const AvancesNutricionales = () => {
   const [nuevo, setNuevo] = useState<Item>({ id: 0, fecha: "", peso: "", grasaCorporal: "" });
   const [alumno, setAlumno] = useState("");
 
-  const pesoData = [
-    { fecha: "Ene", peso: 80 },
-    { fecha: "Feb", peso: 78 },
-    { fecha: "Mar", peso: 76 },
-    { fecha: "Abr", peso: 74 }
+  // Datos de ejemplo para mostrar la mejora en press de banca
+  const fuerzaData = [
+    { fecha: "Ene", pressBanca: 60 },
+    { fecha: "Feb", pressBanca: 65 },
+    { fecha: "Mar", pressBanca: 70 },
+    { fecha: "Abr", pressBanca: 75 }
   ];
 
   const rmData = [
@@ -126,15 +127,15 @@ const AvancesNutricionales = () => {
           <Card>
             <CardContent>
               <Typography variant="h6" gutterBottom>
-                Reducción de Peso
+                Progreso Press de Banca
               </Typography>
               <ResponsiveContainer width="100%" height={250}>
-                <LineChart data={pesoData}>
+                <LineChart data={fuerzaData}>
                   <CartesianGrid strokeDasharray="3 3" stroke="#ccc" />
                   <XAxis dataKey="fecha" />
                   <YAxis />
                   <Tooltip />
-                  <Line type="monotone" dataKey="peso" stroke="#FFA726" />
+                  <Line type="monotone" dataKey="pressBanca" stroke="#FFA726" />
                 </LineChart>
               </ResponsiveContainer>
             </CardContent>


### PR DESCRIPTION
## Summary
- replace `pesoData` with `fuerzaData` on Avances Nutricionales page
- display bench press progress chart instead of weight chart
- update Alumnos detail to show bench press graph instead of weight

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68771c81e41883278744b249aa1cf2ec