### PR TITLE
Restrict login to admin role

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ local.
    ```
    Vite abrirá la aplicación en `http://localhost:5173` por defecto.
 
+## Acceso al sistema
+
+Por simplicidad, la aplicación permite ingresar únicamente con el usuario `admin`.
+Puedes utilizar cualquier contraseña y se generará un token simulado para esa sesión.
+
 ## Desplegar a producción
 
 1. Configura `.env.production` con la URL de la API de producción.

--- a/src/ProtectedLayout.tsx
+++ b/src/ProtectedLayout.tsx
@@ -4,11 +4,12 @@ import AuthService from './services/AuthService';
 import Layout from './layout/Layout';
 
 const ProtectedLayout = () => {
-  // Obtenemos el token guardado durante el login
+  // Obtenemos el token y el rol guardados durante el login
   const token = AuthService.getToken();
+  const role = AuthService.getRole();
 
-  // Si no existe token redirigimos a la pantalla de ingreso
-  if (!token) {
+  // Si no existe token o el rol no es admin redirigimos a la pantalla de ingreso
+  if (!token || role !== 'admin') {
     return <Navigate to="/login" replace />;
   }
   return (

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -20,7 +20,8 @@ const Login = () => {
       navigate('/');
     } catch (err) {
       // Si algo falla mostramos un mensaje de error
-      setError('Credenciales incorrectas');
+      const message = err instanceof Error ? err.message : 'Credenciales incorrectas';
+      setError(message);
     }
   };
 

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -6,23 +6,34 @@ class AuthService {
   async login(username: string, password: string) {
     // En un escenario real se haría una petición al backend usando axios
     // const response = await axios.post(`${API_URL}/login`, { username, password });
-    // const token = response.data.token;
+    // const { token, role } = response.data;
+
+    // Solo permitimos el ingreso del usuario administrador
+    if (username !== 'admin') {
+      throw new Error('Usuario no autorizado');
+    }
 
     // Como la API no está disponible, generamos un token simulado para permitir
     // el ingreso con cualquier contraseña
     const token = btoa(`${username}:${password}`); // token falso
 
-    // Guardamos el token en localStorage para usarlo en las siguientes peticiones
+    // Guardamos el token y el rol en localStorage para usarlo en las siguientes peticiones
     localStorage.setItem('token', token);
+    localStorage.setItem('role', 'admin');
     return token;
   }
 
   logout() {
     localStorage.removeItem('token');
+    localStorage.removeItem('role');
   }
 
   getToken() {
     return localStorage.getItem('token');
+  }
+
+  getRole() {
+    return localStorage.getItem('role');
   }
 }
 


### PR DESCRIPTION
## Summary
- only allow `admin` user to authenticate
- keep role info in `AuthService`
- validate role in `ProtectedLayout`
- show proper login errors
- document login requirement in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68771c9a34e48327a7d7839c21b0058d