### PR TITLE
Add logo image to login page

### DIFF
--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#FFA726" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="50" fill="#fff" font-family="Arial">PF</text>
+</svg>

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -30,6 +30,9 @@ const Login = () => {
       <Card sx={{ width: 300 }}>
         <CardContent>
           <form onSubmit={handleSubmit}>
+            <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
+              <img src="/logo.svg" alt="Logo" style={{ height: 60 }} />
+            </Box>
             <Typography variant="h6" textAlign="center" sx={{ mb: 2 }}>Ingresar</Typography>
             <TextField label="Usuario" variant="outlined" fullWidth margin="normal" value={username} onChange={e => setUsername(e.target.value)} />
             <TextField label="Contrase\u00f1a" type="password" variant="outlined" fullWidth margin="normal" value={password} onChange={e => setPassword(e.target.value)} />


### PR DESCRIPTION
## Summary
- create `logo.svg` with simple PF logo
- display logo image above the inputs in Login form

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6877c8896a808327835ee00591e8fe8b