### PR TITLE
Remove Vite proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,9 @@ VITE_API_BASE_URL=http://localhost:8080
 
 Ajusta el valor de `.env.production` para que apunte a la API real en producción.
 
-Durante el desarrollo, la configuración de Vite incluye un *proxy* que redirige
-las peticiones a rutas que empiecen por `/api` hacia la URL definida en
-`VITE_API_BASE_URL`. Esto evita los problemas de CORS mientras trabajas en
-local.
+Durante el desarrollo la aplicación se comunica directamente con la URL
+especificada en `VITE_API_BASE_URL`, por lo que es necesario que dicho backend
+esté accesible.
 
 ## Levantar el proyecto en local
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,11 +1,8 @@
 import axios from 'axios';
 
-// Cuando se ejecuta en modo desarrollo usamos "/api" para que Vite redireccione
-// las peticiones al backend definido en `VITE_API_BASE_URL` mediante su proxy.
-// En producción se utiliza directamente la URL proporcionada por la variable.
-const baseURL = import.meta.env.DEV
-  ? '/api'
-  : import.meta.env.VITE_API_BASE_URL || '';
+// La URL base del backend se define mediante `VITE_API_BASE_URL` y se utiliza
+// tanto en desarrollo como en producción.
+const baseURL = import.meta.env.VITE_API_BASE_URL || '';
 
 const api = axios.create({
   baseURL

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,19 +1,11 @@
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// Configuración de Vite. Durante el desarrollo se configura un proxy que
-// redirige las llamadas a "/api" al backend indicado en `VITE_API_BASE_URL`.
+// Configuración de Vite sin proxy. Las llamadas a la API deben usar la URL
+// especificada en `VITE_API_BASE_URL`.
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '')
+  loadEnv(mode, process.cwd(), '')
   return {
-    plugins: [react()],
-    server: {
-      proxy: {
-        '/api': {
-          target: env.VITE_API_BASE_URL,
-          changeOrigin: true
-        }
-      }
-    }
+    plugins: [react()]
   }
 })


### PR DESCRIPTION
## Summary
- drop Vite dev proxy configuration
- use `VITE_API_BASE_URL` directly for axios
- update README to explain direct backend connection

## Testing
- `npm run build` *(fails: vite not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6877faf9124c83279e1618b289439e83