### PR TITLE
Replace alerts with MUI modal

### DIFF
--- a/src/utils/alerts.ts
+++ b/src/utils/alerts.ts
@@ -1,7 +1,33 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { Snackbar, Alert } from "@mui/material";
+
+const renderNotification = (
+  message: string,
+  severity: "success" | "error"
+) => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOM.createRoot(container);
+
+  const handleClose = () => {
+    root.unmount();
+    container.remove();
+  };
+
+  root.render(
+    <Snackbar open autoHideDuration={3000} onClose={handleClose}>
+      <Alert onClose={handleClose} severity={severity} sx={{ width: "100%" }}>
+        {message}
+      </Alert>
+    </Snackbar>
+  );
+};
+
 export const showSuccess = (message: string) => {
-  alert(message); // Reemplazar por SweetAlert en un entorno con dependencias
+  renderNotification(message, "success");
 };
 
 export const showError = (message: string) => {
-  alert(message); // Reemplazar por SweetAlert en un entorno con dependencias
+  renderNotification(message, "error");
 };


### PR DESCRIPTION
## Summary
- swap default `alert` popups for a custom MUI Snackbar/Alert

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687803f7772c8327afbc4683055872ed