### PR TITLE
Add exercises management page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Home from "./pages/Home/Home";
 import Alumnos from "./pages/Alumnos/Alumnos";
 import Rutinas from "./pages/Rutinas/Rutinas";
 import Platos from "./pages/Platos/Platos";
+import Ejercicios from "./pages/Ejercicios/Ejercicios";
 import PlanesNutricionales from "./pages/PlanesNutricionales/PlanesNutricionales";
 import Asistencias from "./pages/Asistencias/Asistencias";
 import AvancesNutricionales from "./pages/AvancesNutricionales/AvancesNutricionales";
@@ -26,6 +27,7 @@ function App() {
         <Route path="/ConfiguracionAlumnos" element={<ConfiguracionAlumno />} />
         <Route path="/rutinas" element={<Rutinas />} />
         <Route path="/platos" element={<Platos />} />
+        <Route path="/ejercicios" element={<Ejercicios />} />
         <Route path="/planes" element={<PlanesNutricionales />} />
         <Route path="/asistencias" element={<Asistencias />} />
         <Route path="/avances" element={<AvancesNutricionales />} />

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -15,6 +15,7 @@ import HomeIcon from "@mui/icons-material/Home";
 import PeopleIcon from "@mui/icons-material/People";
 import FitnessCenterIcon from "@mui/icons-material/FitnessCenter";
 import FastfoodIcon from "@mui/icons-material/Fastfood";
+import SportsGymnasticsIcon from "@mui/icons-material/SportsGymnastics";
 import EventIcon from "@mui/icons-material/Event";
 import TimelineIcon from "@mui/icons-material/Timeline";
 import AccountBalanceWalletIcon from "@mui/icons-material/AccountBalanceWallet";
@@ -56,6 +57,10 @@ const SidebarResponsive = () => {
         <ListItem button component={Link} to="/rutinas">
           <ListItemIcon><FitnessCenterIcon sx={{ color: "#FFA726" }} /></ListItemIcon>
           <ListItemText primary="Rutinas" primaryTypographyProps={{ sx: { color: "#ffff" } }} />
+        </ListItem>
+        <ListItem button component={Link} to="/ejercicios">
+          <ListItemIcon><SportsGymnasticsIcon sx={{ color: "#FFA726" }} /></ListItemIcon>
+          <ListItemText primary="Ejercicios" primaryTypographyProps={{ sx: { color: "#ffff" } }} />
         </ListItem>
         <ListItem button component={Link} to="/platos">
           <ListItemIcon><FastfoodIcon sx={{ color: "#FFA726" }} /></ListItemIcon>

--- a/src/pages/Ejercicios/Ejercicios.tsx
+++ b/src/pages/Ejercicios/Ejercicios.tsx
@@ -1,0 +1,153 @@
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  IconButton
+} from "@mui/material";
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import EjerciciosService from "../../services/EjerciciosService";
+import { showError, showSuccess } from "../../utils/alerts";
+
+interface Ejercicio {
+  id: number;
+  nombre: string;
+  explicacion: string;
+  urlVideo: string;
+  imagen?: string;
+}
+
+const Ejercicios = () => {
+  const [items, setItems] = useState<Ejercicio[]>([]);
+  const [open, setOpen] = useState(false);
+  const [detalle, setDetalle] = useState<Ejercicio | null>(null);
+  const [actual, setActual] = useState<Ejercicio>({
+    id: 0,
+    nombre: '',
+    explicacion: '',
+    urlVideo: '',
+    imagen: ''
+  });
+
+  useEffect(() => {
+    EjerciciosService.getAll()
+      .then(r => setItems(r.data))
+      .catch(() => {});
+  }, []);
+
+  const handleGuardar = async () => {
+    try {
+      if (actual.id) {
+        await EjerciciosService.update(actual.id, actual);
+        setItems(items.map(i => (i.id === actual.id ? actual : i)));
+      } else {
+        const response = await EjerciciosService.create(actual);
+        const nuevo = response.data || { ...actual, id: items.length + 1 };
+        setItems([...items, nuevo]);
+      }
+      showSuccess('Ejercicio guardado');
+    } catch (e) {
+      showError('Error al guardar ejercicio');
+    } finally {
+      setOpen(false);
+      setActual({ id: 0, nombre: '', explicacion: '', urlVideo: '', imagen: '' });
+    }
+  };
+
+  const handleEliminar = async (id: number) => {
+    try {
+      await EjerciciosService.delete(id);
+      setItems(items.filter(i => i.id !== id));
+      showSuccess('Ejercicio eliminado');
+    } catch {
+      showError('Error al eliminar ejercicio');
+    }
+  };
+
+  return (
+    <Box>
+      <Typography variant="h5" gutterBottom>Gestión de Ejercicios</Typography>
+      <Button variant="contained" color="warning" startIcon={<AddIcon />} onClick={() => setOpen(true)}>
+        Nuevo Ejercicio
+      </Button>
+
+      <TableContainer component={Paper} sx={{ mt: 2 }}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>ID</TableCell>
+              <TableCell>Nombre</TableCell>
+              <TableCell>Acciones</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {items.map(item => (
+              <TableRow key={item.id}>
+                <TableCell>{item.id}</TableCell>
+                <TableCell>{item.nombre}</TableCell>
+                <TableCell>
+                  <IconButton color="info" onClick={() => setDetalle(item)}>
+                    <VisibilityIcon />
+                  </IconButton>
+                  <IconButton color="primary" onClick={() => { setActual(item); setOpen(true); }}>
+                    <EditIcon />
+                  </IconButton>
+                  <IconButton color="error" onClick={() => handleEliminar(item.id)}>
+                    <DeleteIcon />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Dialog open={open} onClose={() => setOpen(false)}>
+        <DialogTitle>{actual.id ? 'Editar Ejercicio' : 'Nuevo Ejercicio'}</DialogTitle>
+        <DialogContent>
+          <TextField fullWidth margin="dense" label="Nombre" value={actual.nombre} onChange={e => setActual({ ...actual, nombre: e.target.value })} />
+          <TextField fullWidth margin="dense" label="Explicación" value={actual.explicacion} onChange={e => setActual({ ...actual, explicacion: e.target.value })} />
+          <TextField fullWidth margin="dense" label="URL Video" value={actual.urlVideo} onChange={e => setActual({ ...actual, urlVideo: e.target.value })} />
+          <TextField fullWidth margin="dense" label="Imagen" value={actual.imagen} onChange={e => setActual({ ...actual, imagen: e.target.value })} />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpen(false)}>Cancelar</Button>
+          <Button variant="contained" onClick={handleGuardar}>Guardar</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={Boolean(detalle)} onClose={() => setDetalle(null)}>
+        <DialogTitle>{detalle?.nombre}</DialogTitle>
+        <DialogContent>
+          <Typography gutterBottom>{detalle?.explicacion}</Typography>
+          {detalle?.urlVideo && (
+            <Typography gutterBottom>Video: <a href={detalle.urlVideo} target="_blank" rel="noreferrer">{detalle.urlVideo}</a></Typography>
+          )}
+          {detalle?.imagen && (
+            <Box component="img" src={detalle.imagen} alt={detalle.nombre} sx={{ width: '100%', mt: 1 }} />
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDetalle(null)}>Cerrar</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+export default Ejercicios;

--- a/src/services/EjerciciosService.ts
+++ b/src/services/EjerciciosService.ts
@@ -6,6 +6,22 @@ class EjerciciosService {
   getAll() {
     return axios.get(API_URL);
   }
+
+  getById(id: number) {
+    return axios.get(`${API_URL}/${id}`);
+  }
+
+  create(data: any) {
+    return axios.post('/api/ejercicio', data);
+  }
+
+  update(id: number, data: any) {
+    return axios.put(`${API_URL}/${id}`, data);
+  }
+
+  delete(id: number) {
+    return axios.delete(`${API_URL}/${id}`);
+  }
 }
 
 export default new EjerciciosService();


### PR DESCRIPTION
## Summary
- create `Ejercicios` page with CRUD UI for exercises and detail modal
- extend `EjerciciosService` with CRUD methods
- register new `Ejercicios` route in the app
- add sidebar entry for exercises

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68782ccaa7fc8327ad9f9f51699e17c3