### PR TITLE
Connect routine list with API

### DIFF
--- a/src/pages/Rutinas/Rutinas.tsx
+++ b/src/pages/Rutinas/Rutinas.tsx
@@ -94,6 +94,9 @@ const Rutinas = () => {
   useEffect(() => {
     AlumnosService.getAll().then(r => setAlumnos(r.data));
     EjerciciosService.getAll().then(r => setEjercicios(r.data));
+    RutinasService.getAll()
+      .then(r => setItems(r.data))
+      .catch(() => {});
   }, []);
 
   const handleAgregarDia = () => {
@@ -130,8 +133,9 @@ const Rutinas = () => {
     };
 
     try {
-      await RutinasService.create(payload);
-      setItems([...items, payload]);
+      const response = await RutinasService.create(payload);
+      const nuevo = response.data || payload;
+      setItems([...items, nuevo]);
       showSuccess('Rutina guardada correctamente');
     } catch (error) {
       showError('Error al guardar rutina');


### PR DESCRIPTION
## Summary
- load existing routines on page mount
- update list with response from create service

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bceb6b43083278b88a09f2537b9d8