### PR TITLE
Fix default ejercicio selection in Rutinas

### DIFF
--- a/src/pages/Rutinas/Rutinas.tsx
+++ b/src/pages/Rutinas/Rutinas.tsx
@@ -108,8 +108,9 @@ const Rutinas = () => {
 
   const handleAgregarEjercicio = (i: number) => {
     const copy = { ...rutina };
+    const firstEjercicio = ejercicios[0]?.id ?? 0;
     copy.dias[i].ejercicios.push({
-      idEjercicio: 0,
+      idEjercicio: firstEjercicio,
       grupoMuscular: gruposMusculares[0],
       series: 0,
       repeticiones: 0,
@@ -272,7 +273,7 @@ const Rutinas = () => {
                   <FormControl fullWidth margin="dense">
                     <InputLabel>Ejercicio</InputLabel>
                     <Select
-                      value={ej.idEjercicio || ''}
+                      value={ej.idEjercicio}
                       onChange={e => {
                         const val = e.target.value;
                         const copy = { ...rutina };


### PR DESCRIPTION
## Summary
- ensure a valid ejercicio is preselected when adding a new exercise to a routine
- update select control to use the actual id value

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bdca30ecc83278b68777b44c466bb