### PR TITLE
Fix idEjercicio null on new routine

### DIFF
--- a/src/pages/Rutinas/Rutinas.tsx
+++ b/src/pages/Rutinas/Rutinas.tsx
@@ -128,7 +128,8 @@ const Rutinas = () => {
         ...d,
         ejercicios: d.ejercicios.map(e => ({
           ...e,
-          idEjercicio: Number(e.idEjercicio)
+          // Ensure we never send NaN which would be serialized as null
+          idEjercicio: isNaN(Number(e.idEjercicio)) ? 0 : Number(e.idEjercicio)
         }))
       }))
     };


### PR DESCRIPTION
## Summary
- avoid NaN when preparing routine payload

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687be33e58608327877781e35a888b64