### PR TITLE
Fix exercise selection id

### DIFF
--- a/src/pages/Rutinas/Rutinas.tsx
+++ b/src/pages/Rutinas/Rutinas.tsx
@@ -108,9 +108,8 @@ const Rutinas = () => {
 
   const handleAgregarEjercicio = (i: number) => {
     const copy = { ...rutina };
-    const firstEjercicio = ejercicios[0]?.id ?? 0;
     copy.dias[i].ejercicios.push({
-      idEjercicio: firstEjercicio,
+      idEjercicio: 0,
       grupoMuscular: gruposMusculares[0],
       series: 0,
       repeticiones: 0,
@@ -277,9 +276,17 @@ const Rutinas = () => {
                       value={ej.idEjercicio}
                       onChange={e => {
                         const val = e.target.value;
-                        const copy = { ...rutina };
-                        copy.dias[i].ejercicios[j].idEjercicio = val === '' ? 0 : Number(val);
-                        setRutina(copy);
+                        setRutina(prev => {
+                          const copy = { ...prev };
+                          copy.dias = [...prev.dias];
+                          copy.dias[i] = { ...copy.dias[i] };
+                          copy.dias[i].ejercicios = [...copy.dias[i].ejercicios];
+                          copy.dias[i].ejercicios[j] = {
+                            ...copy.dias[i].ejercicios[j],
+                            idEjercicio: val === '' ? 0 : Number(val)
+                          };
+                          return copy;
+                        });
                       }}
                       label="Ejercicio"
                     >


### PR DESCRIPTION
## Summary
- preserve selected exercise ID when saving a routine
- start new exercises with no ID selected

## Testing
- `npm install` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_687be91ad2dc83278abc1d07bca99325