### PR TITLE
Fix routine exercise id handling

### DIFF
--- a/src/pages/Rutinas/Rutinas.tsx
+++ b/src/pages/Rutinas/Rutinas.tsx
@@ -107,16 +107,23 @@ const Rutinas = () => {
   };
 
   const handleAgregarEjercicio = (i: number) => {
-    const copy = { ...rutina };
-    copy.dias[i].ejercicios.push({
-      idEjercicio: 0,
-      grupoMuscular: gruposMusculares[0],
-      series: 0,
-      repeticiones: 0,
-      carga: '',
-      observaciones: '',
+    setRutina(prev => {
+      const copy = { ...prev };
+      copy.dias = [...prev.dias];
+      copy.dias[i] = { ...copy.dias[i] };
+      copy.dias[i].ejercicios = [
+        ...copy.dias[i].ejercicios,
+        {
+          idEjercicio: 0,
+          grupoMuscular: gruposMusculares[0],
+          series: 0,
+          repeticiones: 0,
+          carga: '',
+          observaciones: '',
+        },
+      ];
+      return copy;
     });
-    setRutina(copy);
   };
 
   const handleGuardar = async () => {
@@ -240,9 +247,13 @@ const Rutinas = () => {
                 <Select
                   value={d.dia}
                   onChange={e => {
-                    const copy = { ...rutina };
-                    copy.dias[i].dia = String(e.target.value);
-                    setRutina(copy);
+                    const val = String(e.target.value);
+                    setRutina(prev => {
+                      const copy = { ...prev };
+                      copy.dias = [...prev.dias];
+                      copy.dias[i] = { ...copy.dias[i], dia: val };
+                      return copy;
+                    });
                   }}
                   label="Día"
                 >
@@ -259,9 +270,18 @@ const Rutinas = () => {
                     <Select
                       value={ej.grupoMuscular}
                       onChange={e => {
-                        const copy = { ...rutina };
-                        copy.dias[i].ejercicios[j].grupoMuscular = String(e.target.value);
-                        setRutina(copy);
+                        const val = String(e.target.value);
+                        setRutina(prev => {
+                          const copy = { ...prev };
+                          copy.dias = [...prev.dias];
+                          copy.dias[i] = { ...copy.dias[i] };
+                          copy.dias[i].ejercicios = [...copy.dias[i].ejercicios];
+                          copy.dias[i].ejercicios[j] = {
+                            ...copy.dias[i].ejercicios[j],
+                            grupoMuscular: val,
+                          };
+                          return copy;
+                        });
                       }}
                       label="Grupo Muscular"
                     >
@@ -304,9 +324,18 @@ const Rutinas = () => {
                     margin="dense"
                     value={ej.series}
                     onChange={e => {
-                      const copy = { ...rutina };
-                      copy.dias[i].ejercicios[j].series = Number(e.target.value);
-                      setRutina(copy);
+                      const val = Number(e.target.value);
+                      setRutina(prev => {
+                        const copy = { ...prev };
+                        copy.dias = [...prev.dias];
+                        copy.dias[i] = { ...copy.dias[i] };
+                        copy.dias[i].ejercicios = [...copy.dias[i].ejercicios];
+                        copy.dias[i].ejercicios[j] = {
+                          ...copy.dias[i].ejercicios[j],
+                          series: val,
+                        };
+                        return copy;
+                      });
                     }}
                   />
                   <TextField
@@ -315,9 +344,18 @@ const Rutinas = () => {
                     margin="dense"
                     value={ej.repeticiones}
                     onChange={e => {
-                      const copy = { ...rutina };
-                      copy.dias[i].ejercicios[j].repeticiones = Number(e.target.value);
-                      setRutina(copy);
+                      const val = Number(e.target.value);
+                      setRutina(prev => {
+                        const copy = { ...prev };
+                        copy.dias = [...prev.dias];
+                        copy.dias[i] = { ...copy.dias[i] };
+                        copy.dias[i].ejercicios = [...copy.dias[i].ejercicios];
+                        copy.dias[i].ejercicios[j] = {
+                          ...copy.dias[i].ejercicios[j],
+                          repeticiones: val,
+                        };
+                        return copy;
+                      });
                     }}
                   />
                   <TextField
@@ -326,9 +364,18 @@ const Rutinas = () => {
                     margin="dense"
                     value={ej.carga}
                     onChange={e => {
-                      const copy = { ...rutina };
-                      copy.dias[i].ejercicios[j].carga = e.target.value;
-                      setRutina(copy);
+                      const val = e.target.value;
+                      setRutina(prev => {
+                        const copy = { ...prev };
+                        copy.dias = [...prev.dias];
+                        copy.dias[i] = { ...copy.dias[i] };
+                        copy.dias[i].ejercicios = [...copy.dias[i].ejercicios];
+                        copy.dias[i].ejercicios[j] = {
+                          ...copy.dias[i].ejercicios[j],
+                          carga: val,
+                        };
+                        return copy;
+                      });
                     }}
                   />
                   <TextField
@@ -337,9 +384,18 @@ const Rutinas = () => {
                     margin="dense"
                     value={ej.observaciones}
                     onChange={e => {
-                      const copy = { ...rutina };
-                      copy.dias[i].ejercicios[j].observaciones = e.target.value;
-                      setRutina(copy);
+                      const val = e.target.value;
+                      setRutina(prev => {
+                        const copy = { ...prev };
+                        copy.dias = [...prev.dias];
+                        copy.dias[i] = { ...copy.dias[i] };
+                        copy.dias[i].ejercicios = [...copy.dias[i].ejercicios];
+                        copy.dias[i].ejercicios[j] = {
+                          ...copy.dias[i].ejercicios[j],
+                          observaciones: val,
+                        };
+                        return copy;
+                      });
                     }}
                   />
                 </Box>


### PR DESCRIPTION
## Summary
- avoid mutating state when adding exercises or editing fields
- ensure selected values are kept when saving a routine

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bed5ca49883278d776d963e638076