### PR TITLE
Fix exercise ID parsing

### DIFF
--- a/src/pages/Rutinas/Rutinas.tsx
+++ b/src/pages/Rutinas/Rutinas.tsx
@@ -43,7 +43,7 @@ interface EjercicioItem {
 }
 
 interface EjercicioRutina {
-  idEjercicio: number;
+  idEjercicio: number | string;
   grupoMuscular: string;
   series: number;
   repeticiones: number;
@@ -381,17 +381,11 @@ const Rutinas = () => {
                           copy.dias = [...prev.dias];
                           copy.dias[i] = { ...copy.dias[i] };
                           copy.dias[i].ejercicios = [...copy.dias[i].ejercicios];
-                          const parsed = parseInt(val as string, 10);
+                          const parsed = Number(val);
                           console.log('Parsed ID:', parsed);
-                          if (Number.isNaN(parsed)) {
-                            copy.dias[i].ejercicios[j] = {
-                              ...copy.dias[i].ejercicios[j],
-                              idEjercicio: 0,
-                            };
-                          }
                           copy.dias[i].ejercicios[j] = {
                             ...copy.dias[i].ejercicios[j],
-                            idEjercicio: Number.isNaN(parsed) ? 0 : parsed
+                            idEjercicio: Number.isNaN(parsed) ? val : parsed
                           };
                           return copy;
                         });


### PR DESCRIPTION
## Summary
- support string type for exercise ID in routines
- store raw ID when number parsing fails

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881895387888327902cc70c6ba70e73